### PR TITLE
Release 3.3.2.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+.. _v3-3-2-1:
+
+3.3.2.1 - 2024-01-18
+~~~~~~~~~~~~~~~~~~~~
+
+* Fixed a null-pointer-dereference and segfault that could occur when loading
+  certificates from a PKCS#7 bundle.  Credit to **pkuzco** for reporting the
+  issue. **CVE-2023-49083**
+
 .. _v3-3-2:
 
 3.3.2 - 2021-02-07

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,9 +6,12 @@ Changelog
 3.3.2.1 - 2024-01-18
 ~~~~~~~~~~~~~~~~~~~~
 
-* Fixed a null-pointer-dereference and segfault that could occur when loading
-  certificates from a PKCS#7 bundle.  Credit to **pkuzco** for reporting the
-  issue. **CVE-2023-49083**
+* **SECURITY ISSUE** - Fixed a null-pointer-dereference and segfault that could
+  occur when loading certificates from a PKCS#7 bundle.  Credit to **pkuzco** 
+  for reporting the issue. **CVE-2023-49083**
+
+* **SECURITY ISSUE** - Fixed a bug where ``Cipher.update_into`` accepted Python
+  buffer protocol objects, but allowed immutable buffers. **CVE-2023-23931**
 
 .. _v3-3-2:
 

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -35,6 +35,7 @@ decrypted
 decrypting
 deprecations
 DER
+dereference
 deserialize
 deserialized
 Deserialization

--- a/src/cryptography/__about__.py
+++ b/src/cryptography/__about__.py
@@ -22,7 +22,7 @@ __summary__ = (
 )
 __uri__ = "https://github.com/pyca/cryptography"
 
-__version__ = "3.3.2"
+__version__ = "3.3.2.1"
 
 __author__ = "The cryptography developers"
 __email__ = "cryptography-dev@python.org"

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -2664,9 +2664,12 @@ class Backend(object):
                 _Reasons.UNSUPPORTED_SERIALIZATION,
             )
 
+        certs = []
+        if p7.d.sign == self._ffi.NULL:
+            return certs
+
         sk_x509 = p7.d.sign.cert
         num = self._lib.sk_X509_num(sk_x509)
-        certs = []
         for i in range(num):
             x509 = self._lib.sk_X509_value(sk_x509, i)
             self.openssl_assert(x509 != self._ffi.NULL)

--- a/src/cryptography/hazmat/backends/openssl/ciphers.py
+++ b/src/cryptography/hazmat/backends/openssl/ciphers.py
@@ -135,7 +135,7 @@ class _CipherContext(object):
         data_processed = 0
         total_out = 0
         outlen = self._backend._ffi.new("int *")
-        baseoutbuf = self._backend._ffi.from_buffer(buf)
+        baseoutbuf = self._backend._ffi.from_buffer(buf, require_writable=True)
         baseinbuf = self._backend._ffi.from_buffer(data)
 
         while data_processed != total_data_len:

--- a/tests/hazmat/primitives/test_ciphers.py
+++ b/tests/hazmat/primitives/test_ciphers.py
@@ -310,6 +310,14 @@ class TestCipherUpdateInto(object):
         with pytest.raises(ValueError):
             encryptor.update_into(b"testing", buf)
 
+    def test_update_into_immutable(self, backend):
+        key = b"\x00" * 16
+        c = ciphers.Cipher(AES(key), modes.ECB(), backend)
+        encryptor = c.encryptor()
+        buf = b"\x00" * 32
+        with pytest.raises((TypeError, BufferError)):
+            encryptor.update_into(b"testing", buf)
+
     @pytest.mark.supported(
         only_if=lambda backend: backend.cipher_supported(
             AES(b"\x00" * 16), modes.GCM(b"\x00" * 12)

--- a/tests/hazmat/primitives/test_pkcs7.py
+++ b/tests/hazmat/primitives/test_pkcs7.py
@@ -80,6 +80,12 @@ class TestPKCS7Loading(object):
                 mode="rb",
             )
 
+    def test_load_pkcs7_empty_certificates(self, backend):
+        der = b"\x30\x0B\x06\x09\x2A\x86\x48\x86\xF7\x0D\x01\x07\x02"
+
+        certificates = pkcs7.load_der_pkcs7_certificates(der)
+        assert certificates == []
+
 
 # We have no public verification API and won't be adding one until we get
 # some requirements from users so this function exists to give us basic

--- a/vectors/cryptography_vectors/__about__.py
+++ b/vectors/cryptography_vectors/__about__.py
@@ -20,7 +20,7 @@ __summary__ = "Test vectors for the cryptography package."
 
 __uri__ = "https://github.com/pyca/cryptography"
 
-__version__ = "3.3.2"
+__version__ = "3.3.2.1"
 
 __author__ = "The cryptography developers"
 __email__ = "cryptography-dev@python.org"


### PR DESCRIPTION
AS Release - 3.3.2.1

**CVE-2023-49083**
* Fixed a null-pointer-dereference and segfault that could occur when loading certificates from a PKCS#7 bundle.  Credit to **pkuzco** for reporting the issue. 

**CVE-2023-23931**
* Fixed a bug where ``Cipher.update_into`` accepted Python buffer protocol objects, but allowed immutable buffers. 